### PR TITLE
add defc- support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
+/.idea/
 /.lein-repl-history
 /.project/common
 /.rsync.log
 /pom.xml*
+/react.iml
 /target/

--- a/src/main/cljs/dmohs/react.clj
+++ b/src/main/cljs/dmohs/react.clj
@@ -38,7 +38,7 @@
                      nil))))))))
 
 (defmacro defc [name doc-string-or-fn-map & [fn-map]]
-          `(define false ~name ~doc-string-or-fn-map ~fn-map))
+  `(define false ~name ~doc-string-or-fn-map ~fn-map))
 
 (defmacro defc- [name doc-string-or-fn-map & [fn-map]]
-          `(define true ~name ~doc-string-or-fn-map ~fn-map))
+  `(define true ~name ~doc-string-or-fn-map ~fn-map))

--- a/src/main/cljs/dmohs/react.clj
+++ b/src/main/cljs/dmohs/react.clj
@@ -4,7 +4,7 @@
    [dmohs.react.common :as common]))
 
 
-(defmacro defc [name doc-string-or-fn-map & [fn-map]]
+(defmacro define [private? name doc-string-or-fn-map & [fn-map]]
   (let [[doc-string fn-map] (if (string? doc-string-or-fn-map)
                               [doc-string-or-fn-map fn-map]
                               [nil doc-string-or-fn-map])]
@@ -16,7 +16,10 @@
                                     :get-default-props :render)
            api-keys-used# (set (keys fn-map#))]
        (if-not (cljs.core/exists? ~name)
-         (def ~name (dmohs.react.core/create-class fn-map#))
+         (def ~name
+           ~(if private?
+              `(with-meta (dmohs.react.core/create-class fn-map#) {:private true})
+              `(dmohs.react.core/create-class fn-map#)))
          ;; Assume hot-reload. Instead of redefining the symbol, modify the prototype by replacing
          ;; the methods.
          (let [prototype# (.-prototype ~name)]
@@ -33,3 +36,9 @@
                    (if (contains? api-keys-used# ~'k)
                      (dmohs.react.core/create-camel-cased-react-method-wrapper ~'k)
                      nil))))))))
+
+(defmacro defc [name doc-string-or-fn-map & [fn-map]]
+          `(define false ~name ~doc-string-or-fn-map ~fn-map))
+
+(defmacro defc- [name doc-string-or-fn-map & [fn-map]]
+          `(define true ~name ~doc-string-or-fn-map ~fn-map))

--- a/src/main/cljs/dmohs/react.cljs
+++ b/src/main/cljs/dmohs/react.cljs
@@ -1,5 +1,5 @@
 (ns dmohs.react
-  (:require-macros [dmohs.react :refer [defc]])
+  (:require-macros [dmohs.react :refer [defc defc-]])
   (:require [dmohs.react.core :as core]))
 
 


### PR DESCRIPTION
`:private` appears to be ignored by clojurescript for now, but if it's ever supported, this should ensure that it works. Meanwhile, it's visually different and it works fine.